### PR TITLE
fix: Correct enableEdgeToEdge call

### DIFF
--- a/app/src/main/java/com/verse/of/the/day/MainActivity.java
+++ b/app/src/main/java/com/verse/of/the/day/MainActivity.java
@@ -57,7 +57,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        WindowCompat.enableEdgeToEdge(getWindow());
+        enableEdgeToEdge();
         SharedPreferences shared_preferences = getSharedPreferences("settings", MODE_PRIVATE);
         boolean theme = shared_preferences.getBoolean("theme", false);
         //true is dark theme on


### PR DESCRIPTION
This commit corrects the call to `enableEdgeToEdge` in `MainActivity.java` as per your feedback. The previous call was causing a "cannot find symbol" error during the build process.