### PR TITLE
fix: Import enableEdgeToEdge

### DIFF
--- a/app/src/main/java/com/verse/of/the/day/MainActivity.java
+++ b/app/src/main/java/com/verse/of/the/day/MainActivity.java
@@ -1,5 +1,7 @@
 package com.verse.of.the.day;
 
+import static androidx.core.view.WindowCompat.enableEdgeToEdge;
+
 import androidx.constraintlayout.widget.ConstraintLayout;
 
 import android.view.View;


### PR DESCRIPTION
This commit adds the static import for `enableEdgeToEdge` in `MainActivity.java` to resolve the "cannot find symbol" error.